### PR TITLE
Remove reference to Mamba

### DIFF
--- a/_episodes/01-conda.md
+++ b/_episodes/01-conda.md
@@ -159,14 +159,6 @@ $ conda list
 
 (This list can also be viewed in the environments tab of the Navigator.)
 
-> ## Mamba
->
-> If you find that using conda to install libraries on your computer is slow,
-> try [mamba](https://mamba.readthedocs.io/en/latest/index.html).
-> It's a faster implementation of conda.
->
-{: .callout}
-
 > ## Creating separate environments
 >
 > If you've got multiple data science projects on the go,


### PR DESCRIPTION
I've removed this because I've never used it and don't want to add extra potential confusion (for me...).

Cheers, 

Jonny
